### PR TITLE
Update structural_adaptive_ecc.py

### DIFF
--- a/pyFileFixity/structural_adaptive_ecc.py
+++ b/pyFileFixity/structural_adaptive_ecc.py
@@ -343,7 +343,7 @@ Note2: that Reed-Solomon can correct up to 2*resilience_rate erasures (eg, null 
     main_parser.add_argument('-s', '--size', type=int, default=1024, required=False,
                         help='Headers block size to protect with resilience rate stage 1 (eg: 1024 meants that the first 1k of each file will be protected by stage 1).', **widget_text)
     main_parser.add_argument('-r1', '--resilience_rate_stage1', type=float, default=0.3, required=False,
-                        help='Resilience rate for files headers (eg: 0.3 = 30% of errors can be recovered but size of codeword will be 60% of the data block).', **widget_text)
+                        help='Resilience rate for files headers (eg: 0.3 = 30%% of errors can be recovered but size of codeword will be 60%% of the data block).', **widget_text)
     main_parser.add_argument('-r2', '--resilience_rate_stage2', type=float, default=0.2, required=False,
                         help='Resilience rate for stage 2 (after headers, this is the starting rate applied to the rest of the file, which will be gradually lessened towards the end of the file to the stage 3 rate).', **widget_text)
     main_parser.add_argument('-r3', '--resilience_rate_stage3', type=float, default=0.1, required=False,
@@ -375,7 +375,7 @@ Note2: that Reed-Solomon can correct up to 2*resilience_rate erasures (eg, null 
     main_parser.add_argument('--skip_missing', action='store_true', required=False, default=False,
                         help='Skip missing files (no warning).')
     main_parser.add_argument('--enable_erasures', action='store_true', required=False, default=False,
-                        help='Enable errors-and-erasures correction. Reed-Solomon can correct twice more erasures than errors (eg, if resilience rate is 0.3, then you can correct 30% errors and 60% erasures and any combination of errors and erasures between 30%-60% corruption). An erasure is a corrupted symbol where we know the position, while errors are not known at all. To find erasures, we will find any symbol that is equal to --erasure_symbol and flag it as an erasure. This is particularly useful if the software you use (eg, a disk scraper) can mark bad sectors with a constant character (eg, null byte). Misdetected erasures will just eat one ecc symbol, and won\'t change the decoded message.')
+                        help='Enable errors-and-erasures correction. Reed-Solomon can correct twice more erasures than errors (eg, if resilience rate is 0.3, then you can correct 30%% errors and 60%% erasures and any combination of errors and erasures between 30%%-60%% corruption). An erasure is a corrupted symbol where we know the position, while errors are not known at all. To find erasures, we will find any symbol that is equal to --erasure_symbol and flag it as an erasure. This is particularly useful if the software you use (eg, a disk scraper) can mark bad sectors with a constant character (eg, null byte). Misdetected erasures will just eat one ecc symbol, and won\'t change the decoded message.')
     main_parser.add_argument('--only_erasures', action='store_true', required=False, default=False,
                         help='Enable only erasures correction (no errors). Use this only if you are sure that all corrupted symbols have the same value (eg, if your disk scraper replace bad sectors by null bytes). This will ensure that you can correct up to 2*resilience_rate corrupted symbols.')
     main_parser.add_argument('--erasure_symbol', type=int, default=0, required=False,


### PR DESCRIPTION
I installed pyFileFixity v2.3.1 from PyPI on Debian 10 (testing) with Python 2.7.14. I tried running

```bash
python -m pyFileFixity.structural_adaptive_ecc --help
```

and I was greeted with the error:

```python
Traceback (most recent call last):
  File "/usr/lib/python2.7/runpy.py", line 174, in _run_module_as_main
    "__main__", fname, loader, pkg_name)
  File "/usr/lib/python2.7/runpy.py", line 72, in _run_code
    exec code in run_globals
  File "/usr/local/lib/python2.7/dist-packages/pyFileFixity/structural_adaptive_ecc.py", line 792, in <module>
    sys.exit(main())
  File "/usr/local/lib/python2.7/dist-packages/pyFileFixity/structural_adaptive_ecc.py", line 395, in main
    args = main_parser.parse_args(argv) # Storing all arguments to args
  File "/usr/local/lib/python2.7/dist-packages/pyFileFixity/lib/argparse.py", line 1703, in parse_args
    args, argv = self.parse_known_args(args, namespace)
  File "/usr/local/lib/python2.7/dist-packages/pyFileFixity/lib/argparse.py", line 1735, in parse_known_args
    namespace, args = self._parse_known_args(args, namespace)
  File "/usr/local/lib/python2.7/dist-packages/pyFileFixity/lib/argparse.py", line 1941, in _parse_known_args
    start_index = consume_optional(start_index)
  File "/usr/local/lib/python2.7/dist-packages/pyFileFixity/lib/argparse.py", line 1881, in consume_optional
    take_action(action, args, option_string)
  File "/usr/local/lib/python2.7/dist-packages/pyFileFixity/lib/argparse.py", line 1809, in take_action
    action(self, namespace, argument_values, option_string)
  File "/usr/local/lib/python2.7/dist-packages/pyFileFixity/lib/argparse.py", line 1015, in __call__
    parser.print_help()
  File "/usr/local/lib/python2.7/dist-packages/pyFileFixity/lib/argparse.py", line 2328, in print_help
    self._print_message(self.format_help(), file)
  File "/usr/local/lib/python2.7/dist-packages/pyFileFixity/lib/argparse.py", line 2302, in format_help
    return formatter.format_help()
  File "/usr/local/lib/python2.7/dist-packages/pyFileFixity/lib/argparse.py", line 300, in format_help
    help = self._root_section.format_help()
  File "/usr/local/lib/python2.7/dist-packages/pyFileFixity/lib/argparse.py", line 230, in format_help
    func(*args)
  File "/usr/local/lib/python2.7/dist-packages/pyFileFixity/lib/argparse.py", line 230, in format_help
    func(*args)
  File "/usr/local/lib/python2.7/dist-packages/pyFileFixity/lib/argparse.py", line 536, in _format_action
    help_text = self._expand_help(action)
  File "/usr/local/lib/python2.7/dist-packages/pyFileFixity/lib/argparse.py", line 622, in _expand_help
    return self._get_help_string(action) % params
TypeError: %o format: a number is required, not dict
```

I traced the issue down to a couple help strings containing `%` symbols. The help strings in *argparse* are percent formatted so any literal `%` symbols have to be escaped by doubling them. This minor pull request fixes them.